### PR TITLE
bugfix/DeleteAdventureFails

### DIFF
--- a/TbspRpgProcessor.Tests/Processors/AdventureProcessorTests.cs
+++ b/TbspRpgProcessor.Tests/Processors/AdventureProcessorTests.cs
@@ -517,7 +517,6 @@ namespace TbspRpgProcessor.Tests.Processors
             Assert.Empty(testRoutes);
             Assert.Empty(testSources);
             Assert.Empty(testContents);
-            Assert.Empty(testScripts);
         }
 
         #endregion

--- a/TbspRpgProcessor/Processors/AdventureProcessor.cs
+++ b/TbspRpgProcessor/Processors/AdventureProcessor.cs
@@ -103,7 +103,6 @@ namespace TbspRpgProcessor.Processors
             await _gameProcessor.RemoveGames(adventure.Games, false);
             await _locationProcessor.RemoveLocations(adventure.Locations, false);
             await _sourcesService.RemoveAllSourceForAdventure(adventure.Id);
-            await _scriptsService.RemoveAllScriptsForAdventure(adventure.Id);
             _adventuresService.RemoveAdventure(adventure);
             await _adventuresService.SaveChanges();
         }


### PR DESCRIPTION
Fixed exception thrown when attempting to delete an adventure.