### PR TITLE
bugfix/TRAPI-52 Clear Routes

### DIFF
--- a/TbspRpgApi.Tests/Controllers/RoutesControllerTests.cs
+++ b/TbspRpgApi.Tests/Controllers/RoutesControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 using TbspRpgApi.Controllers;
 using TbspRpgApi.Entities;
@@ -315,6 +316,7 @@ namespace TbspRpgApi.Tests.Controllers
             
             // act
             var response = await controller.UpdateRoutesWithSource(
+                Guid.NewGuid(),
                 new RouteUpdateRequest[]
                 {
                     new()
@@ -344,6 +346,7 @@ namespace TbspRpgApi.Tests.Controllers
             
             // act
             var response = await controller.UpdateRoutesWithSource(
+                Guid.NewGuid(),
                 new RouteUpdateRequest[]
                 {
                     new()

--- a/TbspRpgApi.Tests/Services/RoutesServiceTests.cs
+++ b/TbspRpgApi.Tests/Services/RoutesServiceTests.cs
@@ -186,7 +186,8 @@ namespace TbspRpgApi.Tests.Services
             var service = CreateRoutesService(new List<Route>(), Guid.NewGuid());
             
             // act
-            await service.UpdateRoutesWithSource(new List<RouteUpdateRequest>()
+            await service.UpdateRoutesWithSource(Guid.NewGuid(), 
+                new List<RouteUpdateRequest>()
             {
                 new()
                 {
@@ -211,7 +212,8 @@ namespace TbspRpgApi.Tests.Services
             var service = CreateRoutesService(new List<Route>(), exceptionId);
             
             // act
-            Task Act() => service.UpdateRoutesWithSource(new List<RouteUpdateRequest>()
+            Task Act() => service.UpdateRoutesWithSource(Guid.NewGuid(),
+                new List<RouteUpdateRequest>()
             {
                 new()
                 {

--- a/TbspRpgApi/Controllers/RoutesController.cs
+++ b/TbspRpgApi/Controllers/RoutesController.cs
@@ -96,15 +96,11 @@ namespace TbspRpgApi.Controllers
             return Ok(routes);
         }
         
-        [HttpPut("sync"), Authorize]
-        public async Task<IActionResult> UpdateRoutesWithSource([FromBody] RouteUpdateRequest[] updateRouteRequests)
+        [HttpPut("sync/{locationId:guid}"), Authorize]
+        public async Task<IActionResult> UpdateRoutesWithSource(Guid locationId, [FromBody] RouteUpdateRequest[] updateRouteRequests)
         {
-            if (updateRouteRequests.Length == 0)
-                return Ok(null);
-            
             var canAccessAdventure = await _permissionService.CanWriteLocation(
-                GetUserId().GetValueOrDefault(),
-                updateRouteRequests[0].route.LocationId);
+                GetUserId().GetValueOrDefault(), locationId);
             if (!canAccessAdventure)
             {
                 return BadRequest(new { message = NotYourAdventureErrorMessage });
@@ -112,7 +108,7 @@ namespace TbspRpgApi.Controllers
 
             try
             {
-                await _routesService.UpdateRoutesWithSource(updateRouteRequests);
+                await _routesService.UpdateRoutesWithSource(locationId, updateRouteRequests);
                 return Ok(null);
             }
             catch (Exception ex)

--- a/TbspRpgApi/RequestModels/RouteUpdateRequest.cs
+++ b/TbspRpgApi/RequestModels/RouteUpdateRequest.cs
@@ -1,4 +1,5 @@
-﻿using TbspRpgApi.ViewModels;
+﻿using System;
+using TbspRpgApi.ViewModels;
 using TbspRpgProcessor.Entities;
 
 namespace TbspRpgApi.RequestModels

--- a/TbspRpgApi/Services/RoutesService.cs
+++ b/TbspRpgApi/Services/RoutesService.cs
@@ -14,7 +14,7 @@ namespace TbspRpgApi.Services
     {
         Task<List<RouteViewModel>> GetRoutes(RouteFilterRequest routeFilterRequest);
         Task<RouteViewModel> GetRouteById(Guid routeId);
-        Task UpdateRoutesWithSource(ICollection<RouteUpdateRequest> updateRouteRequests);
+        Task UpdateRoutesWithSource(Guid locationId, ICollection<RouteUpdateRequest> updateRouteRequests);
         Task UpdateRouteWithSource(RouteUpdateRequest updateRouteRequest);
         Task DeleteRoute(Guid routeId);
     }
@@ -47,13 +47,13 @@ namespace TbspRpgApi.Services
             return route != null ? new RouteViewModel(route) : null;
         }
 
-        public async Task UpdateRoutesWithSource(ICollection<RouteUpdateRequest> updateRouteRequests)
+        public async Task UpdateRoutesWithSource(Guid locationId, ICollection<RouteUpdateRequest> updateRouteRequests)
         {
             // remove any routes
             var routeIds = updateRouteRequests.Select(routeRequest => routeRequest.route.Id).ToList();
             await _tbspRpgProcessor.RemoveRoutes(new RoutesRemoveModel() {
                 CurrentRouteIds = routeIds,
-                LocationId = updateRouteRequests.First().route.LocationId
+                LocationId = locationId
             });
             
             foreach (var updateRouteRequest in updateRouteRequests)


### PR DESCRIPTION
Allow empty array of routes so that all routes can be removed from a location.